### PR TITLE
allow user to specify additional assembly resolve folders

### DIFF
--- a/GenerateHtmlDiagrammer.cs
+++ b/GenerateHtmlDiagrammer.cs
@@ -32,10 +32,33 @@ namespace NetAmermaid
             $" You only need to set this if a) you want your diagrams annotated with them and b) the file name differs from that of the {assembly}.")]
         public string? XmlDocs { get; set; }
 
+        [Option('r', "resolve-folders", HelpText = $"Space-separated list of folders to search if assembly lookup fails." + 
+            $" Example might be \"C:\\Program Files\\dotnet\\shared\\Microsoft.AspNetCore.App\\6.0.21\".")]
+        public IEnumerable<string>? AssemblyResolveFolders { get; set; }
+
         public void Run()
         {
             var assemblyPath = GetPath(Assembly);
             var outputFolder = OutputFolder ?? Path.Combine(Path.GetDirectoryName(assemblyPath) ?? string.Empty, "netAmermaid");
+
+            if (AssemblyResolveFolders != null)
+            {
+                List<string> assemblyResolveFoldersFinal = new(AssemblyResolveFolders);
+                assemblyResolveFoldersFinal.Insert(0, Path.GetDirectoryName(assemblyPath));
+                AppDomain.CurrentDomain.AssemblyResolve += (_, args) =>
+                {
+                    string assemblyName = args.Name.Substring(0, args.Name.IndexOf(","));
+                    foreach (string assemblyResolveFolder in assemblyResolveFoldersFinal)
+                    {
+                        string candidateAssemblyFilePath = Path.Combine(assemblyResolveFolder, $"{assemblyName}.dll");
+                        if (File.Exists(candidateAssemblyFilePath))
+                        {
+                            return System.Reflection.Assembly.LoadFrom(candidateAssemblyFilePath);
+                        }
+                    }
+                    return null;
+                };
+            }
             var assembly = System.Reflection.Assembly.LoadFrom(assemblyPath);
             var types = FilterTypes(assembly);
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -133,6 +133,7 @@ The command line app exposes the following parameters.
 | `-b`, `--base-types`       | A regular expression matching the names of common base types in the `assembly`. Set to make displaying repetitive and noisy inheritance details on your diagrams optional via a control in the HTML diagrammer.                  |
 | `-n`, `--strip-namespaces` | Space-separated namespace names that are removed for brevity when displaying member details. Note that the order matters: e.g. replace 'System.Collections' before 'System' to remove both of them completely.                   |
 | `-d`, `--docs`             | The path or file:// URI of the XML file containing the `assembly`'s documentation comments. You only need to set this if a) you want your diagrams annotated with them and b) the file name differs from that of the `assembly`. |
+| `-r`, `--resolve-folders`  | Space-separated list of folders to search if assembly lookup fails. Example might be `"C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App\6.0.21"` if ASP.NET lookup assemblies are missing. |
 
 
 ## Advanced configuration examples


### PR DESCRIPTION
allow user to specify additional assembly resolve folders on the command line in order to resolve missing assemblies especially when pointing to an ASP.NET project. Resolves issue #4 .